### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,6 @@ Just a simple integration for [Bootstrap Icons](https://icons.getbootstrap.com) 
 1. Add `nuxt-bootstrap-icons` dependency to your project
 
    ```bash
-   # Using pnpm
-   npx nuxi@latest module add nuxt-bootstrap-icons
-
-   # Using yarn
-   npx nuxi@latest module add nuxt-bootstrap-icons
-
-   # Using npm
    npx nuxi@latest module add nuxt-bootstrap-icons
    ```
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Just a simple integration for [Bootstrap Icons](https://icons.getbootstrap.com) 
 
    ```bash
    # Using pnpm
-   pnpm add -D nuxt-bootstrap-icons
+   npx nuxi@latest module add nuxt-bootstrap-icons
 
    # Using yarn
-   yarn add --dev nuxt-bootstrap-icons
+   npx nuxi@latest module add nuxt-bootstrap-icons
 
    # Using npm
-   npm install --save-dev nuxt-bootstrap-icons
+   npx nuxi@latest module add nuxt-bootstrap-icons
    ```
 
 2. Add `nuxt-bootstrap-icons` to the `modules` section of `nuxt.config.ts`

--- a/docs/components/Hero.vue
+++ b/docs/components/Hero.vue
@@ -57,7 +57,7 @@ function generateIcons() {
         @click="copyToClipboard(($event.target as HTMLElement).innerText)"
       >
         <BootstrapIcon class="text-xl" name="copy" />
-        <code>pnpm add -D nuxt-bootstrap-icons</code>
+        <code>npx nuxi@latest module add nuxt-bootstrap-icons
       </button>
 
       <!-- Go to release notes -->

--- a/docs/components/Hero.vue
+++ b/docs/components/Hero.vue
@@ -57,7 +57,7 @@ function generateIcons() {
         @click="copyToClipboard(($event.target as HTMLElement).innerText)"
       >
         <BootstrapIcon class="text-xl" name="copy" />
-        <code>npx nuxi@latest module add nuxt-bootstrap-icons
+        <code>npx nuxi@latest module add nuxt-bootstrap-icons</code>
       </button>
 
       <!-- Go to release notes -->

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -13,7 +13,7 @@ Follow the following steps to start using this module:
 1. Add the `nuxt-bootstrap-icons` module to your project as a `devDependency`
 
    ```bash
-   $ pnpm add -D nuxt-bootstrap-icons
+   $ npx nuxi@latest module add nuxt-bootstrap-icons
    ```
 
 2. Add the module to the `modules` section of the `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
